### PR TITLE
Create an instance of Ul, using prototype fields.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,8 @@ console.log(tmp === Ul.clone(tmp));
 ```
 
 # Documentation
-## `merge(obj1, obj2)`
-Merges two objects. The second parameter has higher priority.
-That means the defaults will be passed in the first parameter.
-
-### Params
-- **Object** `obj1`: The first object.
-- **Object** `obj2`: The second object.
+## `merge(/* obj1, obj2, obj3, ..., objN*/)`
+Recursively merge the objects from arguments, returning a new object.
 
 ### Return
 - **Object** The merged objects.

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,10 +1,10 @@
 // Constructor
-var Ul = module.exports = {};
+function Ul() {}
 
 /**
  * merge
- * Merges two objects. The second parameter has higher priority.
- * That means the defaults will be passed in the first parameter.
+ * Recursively merge properties and return new object.
+ * obj1 <- obj2 [ <- ... ]
  *
  * @name merge
  * @function
@@ -12,21 +12,30 @@ var Ul = module.exports = {};
  * @param {Object} obj2 The second object.
  * @return {Object} The merged objects.
  */
-Ul.merge = function (obj1, obj2) {
+Ul.prototype.merge = function (/*obj1, obj2, obj3, ..., objn */) {
 
-    for (var p in obj2) {
-        try {
-            if (obj2[p].constructor == Object) {
-                obj1[p] = Ul.merge(obj1[p], obj2[p]);
+    var dst = {}
+      , src
+      , p
+      , args = [].splice.call(arguments, 0)
+      ;
+
+    while (args.length > 0) {
+        src = args.splice(-1)[0];
+        if (toString.call(src) != "[object Object]") { continue; }
+        for (p in src) {
+            if (!src.hasOwnProperty(p)) { continue; }
+            if (toString.call(src[p]) == "[object Object]") {
+                dst[p] = this.merge(dst[p] || {}, src[p]);
             } else {
-                obj1[p] = obj2[p];
+                if (src[p] !== undefined) {
+                    dst[p] = src[p];
+                }
             }
-        } catch (e) {
-            obj1[p] = obj2[p];
         }
     }
 
-    return obj1;
+    return dst;
 };
 
 /**
@@ -38,10 +47,11 @@ Ul.merge = function (obj1, obj2) {
  * @param {Anything} item The item that should be cloned
  * @return {Anything} The cloned object
  */
-Ul.clone = function (item) {
+Ul.prototype.clone = function (item) {
 
     if (!item) { return item; }
-    var types = [Number, String, Boolean]
+    var self = this
+      , types = [Number, String, Boolean]
       , result
       , i
       ;
@@ -56,7 +66,7 @@ Ul.clone = function (item) {
         if (Array.isArray(item)) {
             result = [];
             item.forEach(function(child, index) {
-                result[index] = Ul.clone(child);
+                result[index] = self.clone(child);
             });
         } else if (typeof item == "object") {
             if (!item.prototype) {
@@ -65,7 +75,7 @@ Ul.clone = function (item) {
                 } else {
                     result = {};
                     for (i in item) {
-                        result[i] = Ul.clone(item[i]);
+                        result[i] = self.clone(item[i]);
                     }
                 }
             } else {
@@ -80,4 +90,6 @@ Ul.clone = function (item) {
 };
 
 // Returns the absolute path to the user directory (`~/`)
-Ul.USER_DIR = process.env[(process.platform == 'win32') ? 'USERPROFILE' : 'HOME'];
+Ul.prototype.USER_DIR = process.env[(process.platform == "win32") ? "USERPROFILE" : "HOME"];
+
+module.exports = new Ul();

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,13 +3,10 @@ function Ul() {}
 
 /**
  * merge
- * Recursively merge properties and return new object.
- * obj1 <- obj2 [ <- ... ]
+ * Recursively merge the objects from arguments, returning a new object.
  *
  * @name merge
  * @function
- * @param {Object} obj1 The first object.
- * @param {Object} obj2 The second object.
  * @return {Object} The merged objects.
  */
 Ul.prototype.merge = function (/*obj1, obj2, obj3, ..., objn */) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ul",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "A minimalist utility library.",
   "main": "lib/index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -9,9 +9,13 @@ var obj = {
       , v: 10
       , a: 20
     }
+  , last = { c: 1 }
   , tmp = null
   ;
 
-console.log(tmp = Ul.merge(def, obj));
+console.log(tmp = Ul.merge(obj, def));
 console.log(tmp === Ul.clone(tmp));
 console.log(Ul.USER_DIR);
+console.log(Ul.merge({}, obj, def, last));
+console.log(Ul.merge({ a: { c: {}, d: 3 } }, { a: {d: undefined, c: {s: {}}} }));
+console.log(Ul.merge({ a: 4, b: 1 }, { b: 2, c: 3 }));


### PR DESCRIPTION
- Fixed #2. Inversed the two parameters in the merge method.
- Fixed #3. Now empty objects are merged correctly.
- Fixed #4. Support unlimited merge arguments.
- Fixed #5. Do not consider undefined as real object value.
