### PR TITLE
5.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ var obj = {
   ;
 
 // Merge the two objects and store the result in tmp
-console.log(tmp = Ul.merge(obj, def));
+console.log(tmp = Ul.deepMerge(obj, def));
 // => { n: null, v: 1, a: 20 }
 
 // Clone the tmp object -- the clone will have a
@@ -55,14 +55,37 @@ console.log(tmp === Ul.clone(tmp));
 console.log(Ul.home()); // or `console.log(Ul.HOME_DIR);`
 // => /home/ionicabizau
 
+// One level merge
+console.log(Ul.merge({
+    foo: {
+        bar: 42
+    }
+}, {
+    foo: {
+        bar: 1
+      , baz: 7
+    }
+});
+// => { { bar: 42 } }
+
 ```
 
 ## Documentation
 
-### `merge()`
+### `merge(dst, src)`
+One level merge. Faster than `deepMerge`.
+
+#### Params
+- **** `dst`: {Object} The destination object.
+- **** `src`: {Object} The source object (usually defaults).
+
+#### Return
+- **Object** The result object.
+
+### `deepMerge()`
 Recursively merge the objects from arguments, returning a new object.
 
-Usage: `Ul.merge(obj1, obj2, obj3, obj4, ..., objN)`
+Usage: `Ul.deepMerge(obj1, obj2, obj3, obj4, ..., objN)`
 
 #### Return
 - **Object** The merged objects.

--- a/example/index.js
+++ b/example/index.js
@@ -15,7 +15,7 @@ var obj = {
   ;
 
 // Merge the two objects and store the result in tmp
-console.log(tmp = Ul.merge(obj, def));
+console.log(tmp = Ul.deepMerge(obj, def));
 // => { n: null, v: 1, a: 20 }
 
 // Clone the tmp object -- the clone will have a
@@ -26,3 +26,16 @@ console.log(tmp === Ul.clone(tmp));
 // Show the absolute path to the home directory
 console.log(Ul.home()); // or `console.log(Ul.HOME_DIR);`
 // => /home/ionicabizau
+
+// One level merge
+console.log(Ul.merge({
+    foo: {
+        bar: 42
+    }
+}, {
+    foo: {
+        bar: 1
+      , baz: 7
+    }
+});
+// => { { bar: 42 } }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,6 @@
+// Dependencies
+var Typpy = require("typpy");
+
 // Constructor
 function Ul() {}
 
@@ -21,10 +24,10 @@ Ul.prototype.merge = function () {
 
     while (args.length > 0) {
         src = args.splice(-1)[0];
-        if (toString.call(src) != "[object Object]") { continue; }
+        if (Typpy(src) !== "object") { continue; }
         for (p in src) {
             if (!src.hasOwnProperty(p)) { continue; }
-            if (toString.call(src[p]) == "[object Object]") {
+            if (Typpy(src[p]) === "object") {
                 dst[p] = this.merge(src[p], dst[p] || {});
             } else {
                 if (src[p] !== undefined) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,20 +1,51 @@
 // Dependencies
-var Typpy = require("typpy");
+var Typpy = require("typpy")
+  , Deffy = require("deffy")
+  ;
 
 // Constructor
 function Ul() {}
 
 /**
  * merge
- * Recursively merge the objects from arguments, returning a new object.
- *
- * Usage: `Ul.merge(obj1, obj2, obj3, obj4, ..., objN)`
+ * One level merge. Faster than `deepMerge`.
  *
  * @name merge
  * @function
+ * @param dst {Object} The destination object.
+ * @param src {Object} The source object (usually defaults).
+ * @return {Object} The result object.
+ */
+Ul.prototype.merge = function (dst, src, p) {
+    var res = {}
+      , k = null
+      ;
+
+    src = Deffy(src, {});
+    dst = Deffy(dst, {});
+
+    for (k in src) { res[k] = src[k]; }
+    for (k in dst) {
+        if (undefined === dst[k]) {
+            continue;
+        }
+        res[k] = dst[k];
+    }
+
+    return res;
+};
+
+/**
+ * deepMerge
+ * Recursively merge the objects from arguments, returning a new object.
+ *
+ * Usage: `Ul.deepMerge(obj1, obj2, obj3, obj4, ..., objN)`
+ *
+ * @name deepMerge
+ * @function
  * @return {Object} The merged objects.
  */
-Ul.prototype.merge = function () {
+Ul.prototype.deepMerge = function () {
 
     var dst = {}
       , src
@@ -28,7 +59,7 @@ Ul.prototype.merge = function () {
         for (p in src) {
             if (!src.hasOwnProperty(p)) { continue; }
             if (Typpy(src[p]) === "object") {
-                dst[p] = this.merge(src[p], dst[p] || {});
+                dst[p] = this.deepMerge(src[p], dst[p] || {});
             } else {
                 if (src[p] !== undefined) {
                     dst[p] = src[p];

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "test": "test"
   },
   "dependencies": {
-    "typpy": "2.0.0"
+    "typpy": "2.0.0",
+    "deffy": "2.0.0"
   },
   "devDependencies": {
     "mocha": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ul",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "A minimalist utility library.",
   "main": "lib/index.js",
   "scripts": {
@@ -25,7 +25,9 @@
     "example": "example",
     "test": "test"
   },
-  "dependencies": {},
+  "dependencies": {
+    "typpy": "1.0.0"
+  },
   "devDependencies": {
     "mocha": "^2.2.5",
     "is-there": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test": "test"
   },
   "dependencies": {
-    "typpy": "1.0.0"
+    "typpy": "2.0.0"
   },
   "devDependencies": {
     "mocha": "^2.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ul",
-  "version": "5.0.0",
+  "version": "6.0.0",
   "description": "A minimalist utility library.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ul",
-  "version": "6.0.0",
+  "version": "5.0.0",
   "description": "A minimalist utility library.",
   "main": "lib/index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -20,7 +20,7 @@ var obj = {
 
 // One level objects
 it("should merge one level objects", function (cb) {
-    tmp = Ul.merge(obj, def);
+    tmp = Ul.deepMerge(obj, def);
     Assert.deepEqual(tmp, {
         n: null
       , v: 1
@@ -44,7 +44,7 @@ it("should get the correct path to the home directory", function (cb) {
 
 // Multiple objects merge
 it("should merge more than two objects", function (cb) {
-    Assert.deepEqual(Ul.merge({}, obj, def, last), {
+    Assert.deepEqual(Ul.deepMerge({}, obj, def, last), {
         c: 1
       , n: null
       , v: 1
@@ -55,7 +55,7 @@ it("should merge more than two objects", function (cb) {
 
 // Deep merge
 it("should merge objects deeply", function (cb) {
-    Assert.deepEqual(Ul.merge({
+    Assert.deepEqual(Ul.deepMerge({
         a: {
             c: {}
           , d: 3
@@ -80,7 +80,7 @@ it("should merge objects deeply", function (cb) {
 
 // Merge arrays
 it("should merge arrays", function (cb) {
-    Assert.deepEqual(Ul.merge({
+    Assert.deepEqual(Ul.deepMerge({
         a: 4
       , b: 1
       , d: {
@@ -103,6 +103,23 @@ it("should merge arrays", function (cb) {
             }
         }
       , a: 4
+    });
+    cb();
+});
+
+// One level merge
+it("should merge one level objects", function (cb) {
+    Assert.deepEqual(Ul.merge({
+        foo: {
+            bar: 42
+        }
+    }, {
+        foo: {
+            bar: 1
+          , baz: 7
+        }
+    }), {
+        foo: { bar: 42 }
     });
     cb();
 });


### PR DESCRIPTION
- Fixes #9. Use `typpy` to check for objects.
- Added `merge` method for merging one level objects.
- Renamed the old `merge` to `deepMerge`.
